### PR TITLE
Ensure Appboy Data Flush while in background

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,5 +15,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.appboy:android-sdk-ui:1.15.2'
+    compile 'com.appboy:android-sdk-ui:1.15.3'
 }


### PR DESCRIPTION
The mParticle SDK can be initialized while an app is running in the background, and may forward user attributes to the Appboy SDK during this time. The Appboy SDK will only upload attributes if there is an active session (if the app is in the foreground), or if manually told to do so. This change addresses this disparity by forcing a data flush after user attributes are set in the background.