### PR TITLE
Remove logic to process Cluster setting

### DIFF
--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -39,24 +39,6 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
     static final String FORWARD_SCREEN_VIEWS = "forwardScreenViews";
 
     static final String HOST = "host";
-    static final String DATA_CENTER_LOCATION = "dataCenterLocation";
-
-    static Map<String, String> clusterMap = new HashMap<String, String>(){{
-        put(LOCATION_EU, EU_HOST);
-        put(CLUSTER_ONE, CLUSTER_ONE_HOST);
-        put(CLUSTER_TWO, CLUSTER_TWO_HOST);
-        put(CLUSTER_THREE, CLUSTER_THREE_HOST);
-    }};
-
-    static final String LOCATION_EU = "EU";
-    static final String CLUSTER_ONE = "01";
-    static final String CLUSTER_TWO = "02";
-    static final String CLUSTER_THREE = "03";
-
-    static final String EU_HOST = "sdk.api.appboy.eu";
-    static final String CLUSTER_ONE_HOST = "dev.appboy.com";
-    static final String CLUSTER_TWO_HOST = "sdk-02.iad.appboy.com";
-    static final String CLUSTER_THREE_HOST = "sdk-03.iad.appboy.com";
 
     public static final String PUSH_ENABLED = "push_enabled";
     private static final String PREF_KEY_HAS_SYNCED_ATTRIBUTES = "appboy::has_synced_attributes";
@@ -80,25 +62,8 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
 
         //try to get endpoint from the host setting
         String authority = settings.get(HOST);
-        if (authority == null) {
-            String clusterHost = settings.get(DATA_CENTER_LOCATION);
-            if (!KitUtils.isEmpty(clusterHost) && clusterMap.containsKey(clusterHost)) {
-                authority = clusterMap.get(clusterHost);
-            }
-        }
-        // if endpoint was either included in the host setting, or was able to be set by the data center
-        // location set it, otherwise, use default endpoint
-        if (authority != null) {
-            final String finalAuthority = authority;
-            Appboy.setAppboyEndpointProvider(
-                    new IAppboyEndpointProvider() {
-                        @Override
-                        public Uri getApiEndpoint(Uri appboyEndpoint) {
-                            return appboyEndpoint.buildUpon()
-                                    .authority(finalAuthority).build();
-                        }
-                    }
-            );
+        if (!KitUtils.isEmpty(authority)) {
+            setAuthority(authority);
         }
 
         forwardScreenViews = Boolean.parseBoolean(settings.get(FORWARD_SCREEN_VIEWS));
@@ -251,7 +216,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
         return true;
     }
 
-    private void queueDataFlush() {
+    void queueDataFlush() {
         dataFlushHandler.removeCallbacks(dataFlushRunnable);
         dataFlushHandler.postDelayed(dataFlushRunnable, FLUSH_DELAY);
     }
@@ -369,5 +334,17 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
         } else {
             return false;
         }
+    }
+
+    protected void setAuthority(final String authority) {
+        Appboy.setAppboyEndpointProvider(
+                new IAppboyEndpointProvider() {
+                    @Override
+                    public Uri getApiEndpoint(Uri appboyEndpoint) {
+                        return appboyEndpoint.buildUpon()
+                                .authority(authority).build();
+                    }
+                }
+        );
     }
 }

--- a/src/test/java/com/mparticle/kits/AppboyKitTests.java
+++ b/src/test/java/com/mparticle/kits/AppboyKitTests.java
@@ -1,13 +1,20 @@
 package com.mparticle.kits;
 
 
+import android.app.Application;
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.support.annotation.Nullable;
+import android.test.mock.MockApplication;
+import android.test.mock.MockContext;
 
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -55,4 +62,192 @@ public class AppboyKitTests {
         }
         fail(className + " not found as a known integration.");
     }
+
+    String hostName = "aRandomHost";
+    @Test
+    public void testHostSetting() throws Exception {
+        Map<String, String> settings = new HashMap<>();
+        settings.put(AppboyKit.HOST, hostName);
+        settings.put(AppboyKit.APPBOY_KEY, "key");
+        MockAppboyKit kit = new MockAppboyKit();
+        kit.onKitCreate(settings, new MockContextApplication());
+        assertTrue(kit.calledAuthority[0].equals(hostName));
+    }
+
+    @Test
+    public void testHostSettingNull() throws Exception {
+        //test that the key is set when it is passed in by the settings map
+        Map<String, String> missingSettings = new HashMap<>();
+        missingSettings.put(AppboyKit.APPBOY_KEY, "key");
+        MockAppboyKit kit = new MockAppboyKit();
+        try {
+        kit.onKitCreate(missingSettings, new MockContextApplication());
+        } catch (Exception e) {}
+        assertTrue(kit.calledAuthority[0] == null);
+    }
+    @Test
+    public void testHostSettingEmpty() throws Exception {
+        Map<String, String> nullSettings = new HashMap<>();
+        nullSettings.put(AppboyKit.HOST, null);
+        nullSettings.put(AppboyKit.APPBOY_KEY, "key");
+        MockAppboyKit kit = new MockAppboyKit();
+        try {
+            kit.onKitCreate(nullSettings, new MockContextApplication());
+        } catch (Exception e) {}
+        assertTrue(kit.calledAuthority[0] == null);
+
+        nullSettings = new HashMap<>();
+        nullSettings.put(AppboyKit.HOST, "");
+        nullSettings.put(AppboyKit.APPBOY_KEY, "key");
+        kit = new MockAppboyKit();
+        try {
+            kit.onKitCreate(nullSettings, new MockContextApplication());
+        } catch (Exception e) {}
+        assertTrue(kit.calledAuthority[0] == null);
+    }
+
+
+
+    class MockAppboyKit extends AppboyKit {
+        final String[] calledAuthority = new String[1];
+
+        @Override
+        protected void setAuthority(String authority) {
+            calledAuthority[0] = authority;
+        }
+
+        @Override
+        void queueDataFlush() {
+            //do nothing
+        }
+    }
+
+    class MockContextApplication extends MockApplication {
+        @Override
+        public Context getApplicationContext() {
+            return this;
+        }
+
+        @Override
+        public SharedPreferences getSharedPreferences(String name, int mode) {
+            return new MockSharedPreferences();
+        }
+
+        @Override
+        public void registerActivityLifecycleCallbacks(ActivityLifecycleCallbacks callback) {
+            //do nothing
+        }
+    }
+
+    class MockSharedPreferences implements SharedPreferences, SharedPreferences.Editor {
+
+
+        @Override
+        public Map<String, ?> getAll() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public String getString(String key, @Nullable String defValue) {
+            return "";
+        }
+
+        @Nullable
+        @Override
+        public Set<String> getStringSet(String key, @Nullable Set<String> defValues) {
+            return new TreeSet<>();
+        }
+
+        @Override
+        public int getInt(String key, int defValue) {
+            return 0;
+        }
+
+        @Override
+        public long getLong(String key, long defValue) {
+            return 0;
+        }
+
+        @Override
+        public float getFloat(String key, float defValue) {
+            return 0;
+        }
+
+        @Override
+        public boolean getBoolean(String key, boolean defValue) {
+            return false;
+        }
+
+        @Override
+        public boolean contains(String key) {
+            return false;
+        }
+
+        @Override
+        public Editor edit() {
+            return this;
+        }
+
+        @Override
+        public void registerOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+
+        }
+
+        @Override
+        public void unregisterOnSharedPreferenceChangeListener(OnSharedPreferenceChangeListener listener) {
+
+        }
+
+        @Override
+        public Editor putString(String key, @Nullable String value) {
+            return this;
+        }
+
+        @Override
+        public Editor putStringSet(String key, @Nullable Set<String> values) {
+            return this;
+        }
+
+        @Override
+        public Editor putInt(String key, int value) {
+            return this;
+        }
+
+        @Override
+        public Editor putLong(String key, long value) {
+            return this;
+        }
+
+        @Override
+        public Editor putFloat(String key, float value) {
+            return this;
+        }
+
+        @Override
+        public Editor putBoolean(String key, boolean value) {
+            return this;
+        }
+
+        @Override
+        public Editor remove(String key) {
+            return this;
+        }
+
+        @Override
+        public Editor clear() {
+            return this;
+        }
+
+        @Override
+        public boolean commit() {
+            return false;
+        }
+
+        @Override
+        public void apply() {
+
+        }
+    }
+
 }


### PR DESCRIPTION
1) Remove hardcoded cluster mappings
- Previously, we were looking for either a "host" or a "cluster" from the server, the "cluster" would be mapped to a hard-coded "host". This PR alters the behavior in that now, we are only looking for a "host" in the kit settings. We have also removed the hard-code cluster-host mappings
2) Add unit tests
- test that the host is set, when we receive it in the kit settings
- test that we use the default Appboy host (aka do not explicitly set the host), when the "host" is not found in the settings