### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the [Appboy](https://www.appboy.com/) integration for t
 
     ```
     repositories {
-        maven { url "http://appboy.github.io/appboy-android-sdk/sdk" }
+        maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
         //Appboy's library depends on the Google Support Library, which is now distributed via Maven
         maven { url "https://maven.google.com" }
         ...


### PR DESCRIPTION
Updated the appboy maven repository to use https instead of http. Using http was causing builds to fail to resolve dependencies when behind a proxy. Just trying to protect future developers against any small issues that could be a headache.