### PR TITLE
Remove setting AppBoy blacklisted views

### DIFF
--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -83,7 +83,6 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
             }
         };
         queueDataFlush();
-        ((Application) context.getApplicationContext()).registerActivityLifecycleCallbacks(new AppboyLifecycleCallbackListener());
         return null;
     }
 

--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -52,6 +52,8 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
     private Runnable dataFlushRunnable;
     final private static int FLUSH_DELAY = 5000;
     private boolean forwardScreenViews = false;
+    
+    public static boolean setDefaultAppboyLifecycleCallbackListener = true;
 
     @Override
     public String getName() {
@@ -83,6 +85,9 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
             }
         };
         queueDataFlush();
+        if (setDefaultAppboyLifecycleCallbackListener) {
+            ((Application) context.getApplicationContext()).registerActivityLifecycleCallbacks(new AppboyLifecycleCallbackListener());
+        }
         return null;
     }
 


### PR DESCRIPTION
We're running into an issue where when using the AppBoy (a.k.a. Braze) kit, we can't set blacklisted views in our implementation.
I don't see why mParticle should bother with setting this for users of the library.

It seems like something not required by the kit, but that should be set by the client.

This is currently preventing us from using the kit, but now of course we're not seeing our data in our Braze console