### PR TITLE
Enable parsing to implied type for String Attributes

### DIFF
--- a/src/test/java/com/appboy/Appboy.java
+++ b/src/test/java/com/appboy/Appboy.java
@@ -8,12 +8,15 @@ import com.mparticle.kits.AppboyPurchase;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Appboy {
     private static Appboy instance;
     private AppboyUser currentUser;
     private List<AppboyPurchase> purchases = new ArrayList<>();
+    private Map<String, AppboyProperties> events = new HashMap<String, AppboyProperties>();
 
     public static boolean configure(Context context, AppboyConfig config) {
         return true;
@@ -34,7 +37,7 @@ public class Appboy {
     }
 
     public void logCustomEvent(String key, AppboyProperties appboyProperties) {
-
+        events.put(key, appboyProperties);
     }
 
     public void logPurchase(String sku, String currency, BigDecimal unitPrice, int quantity, AppboyProperties purchaseProperties) {
@@ -45,7 +48,15 @@ public class Appboy {
         return purchases;
     }
 
+    public Map<String, AppboyProperties> getEvents() {
+        return events;
+    }
+
     public void clearPurchases() {
         purchases.clear();
+    }
+
+    public void clearEvents() {
+        events.clear();
     }
 }

--- a/src/test/java/com/appboy/MockAppboyUser.java
+++ b/src/test/java/com/appboy/MockAppboyUser.java
@@ -29,7 +29,7 @@ public class MockAppboyUser extends AppboyUser {
     }
 
     private Map<String, List<String>> customAttributeArray = new HashMap<>();
-    private Map<String, String> customAttributes = new HashMap<>();
+    private Map<String, Object> customAttributes = new HashMap<>();
 
     public Map<String, List<String>> getCustomAttributeArray() {
         return customAttributeArray;
@@ -62,7 +62,25 @@ public class MockAppboyUser extends AppboyUser {
         return true;
     }
 
-    public Map<String, String> getCustomUserAttributes() {
+    @Override
+    public boolean setCustomUserAttribute(String key, boolean value) {
+        customAttributes.put(key, value);
+        return true;
+    }
+
+    @Override
+    public boolean setCustomUserAttribute(String key, int value) {
+        customAttributes.put(key, value);
+        return true;
+    }
+
+    @Override
+    public boolean setCustomUserAttribute(String key, double value) {
+        customAttributes.put(key, value);
+        return true;
+    }
+
+    public Map<String, Object> getCustomUserAttributes() {
         return customAttributes;
     }
 }

--- a/src/test/java/com/appboy/models/outgoing/AppboyProperties.java
+++ b/src/test/java/com/appboy/models/outgoing/AppboyProperties.java
@@ -29,6 +29,11 @@ public class AppboyProperties {
         return this;
     }
 
+    public AppboyProperties addProperty(String key, boolean value) {
+        properties.put(key, value);
+        return this;
+    }
+
     public Map<String, Object> getProperties() {
         return properties;
     }


### PR DESCRIPTION
## Settings 
Broke out the logic we were using to detect type for UserAttribtues and applied it to custom event Attributes, as well one place we didn't have the logic applied when setting UserAttribtues.

## Master Issue
Closes https://go.mparticle.com/work/48843