### PR TITLE
fix: bugfix https warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains an [example app](https://github.com/mparticle-integrati
 
     ```
     repositories {
-        maven { url "http://appboy.github.io/appboy-android-sdk/sdk" }
+        maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
         //Braze's library depends on the Google Support Library
         google()
         ...

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ android {
 }
 
 repositories {
-    maven { url "http://appboy.github.io/appboy-android-sdk/sdk" }
+    maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
 }
 
 dependencies {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -31,7 +31,7 @@ android {
 
 repositories {
     jcenter()
-    maven { url "http://appboy.github.io/appboy-android-sdk/sdk" } //REQUIRED: Braze isn't available in jCenter or Maven Central - so you need to add their Maven Server
+    maven { url "https://appboy.github.io/appboy-android-sdk/sdk" } //REQUIRED: Braze isn't available in jCenter or Maven Central - so you need to add their Maven Server
     google()
 }
 


### PR DESCRIPTION
## Summary
Updated `http://` urls to `https://` blocking lint in AGP 7.X upgrade

## Testing Plan
Check if any other `http://` references exist to upgrade