### PR TITLE
fix: prevent converting stringified zipcode to integer

### DIFF
--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -275,6 +275,8 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
             } catch (Exception e) {
                 Logger.error("unable to set DateOfBirth for \"dob\" = " + value + ". Exception: " + e.getMessage());
             }
+        } else if(UserAttributes.ZIPCODE.equals(key)){
+            user.setCustomUserAttribute("Zip", value);
         } else {
             if (key.startsWith("$")) {
                 key = key.substring(1);

--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -275,7 +275,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
             } catch (Exception e) {
                 Logger.error("unable to set DateOfBirth for \"dob\" = " + value + ". Exception: " + e.getMessage());
             }
-        } else if(UserAttributes.ZIPCODE.equals(key)){
+        } else if (UserAttributes.ZIPCODE.equals(key)) {
             user.setCustomUserAttribute("Zip", value);
         } else {
             if (key.startsWith("$")) {


### PR DESCRIPTION
Summary
Food Truck Inc. has reported that when they use our reserved zipcode attribute it gets converted to a number/integer due to enabling the datatype detection in which is needed for other non-reserved attributes. This results in some zipcodes appearing wrong in some cases (for example: inputting "07090" as a zipcode would be forwarded to Braze as 7090).

Testing Plan
Tested the reserved zipcodes both if entered as a string value or a numeric value. Works fine on both whereas in the case of numeric values it would be stringified (in the case for some reason clients were passing reserved zipcode attribute as an integer).