### PR TITLE
feat: Surface option to not expand non-purchase ecomm events

### DIFF
--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -246,7 +246,12 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
                     productArray.put(newAttributes);
                 }
                 try {
-                    BrazeProperties brazeProperties = new BrazeProperties(new JSONObject().put("Transaction ID", event.getTransactionAttributes().getId()).put("products", productArray));
+                    JSONObject json = new JSONObject().put("products", productArray);
+                    TransactionAttributes transactionAttributes = event.getTransactionAttributes();
+                    if (transactionAttributes != null) {
+                        json.put("Transaction ID",  transactionAttributes.getId();
+                    }
+                    BrazeProperties brazeProperties = new BrazeProperties(json);
                     Braze.getInstance(getContext()).logCustomEvent(eventList.get(0).getEventName(), brazeProperties);
                     messages.add(ReportingMessage.fromEvent(this, event));
                 } catch (JSONException e) {

--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -81,7 +81,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
     protected List<ReportingMessage> onKitCreate(Map<String, String> settings, Context context) {
         String key = settings.get(APPBOY_KEY);
         if (KitUtils.isEmpty(key)) {
-            throw new IllegalArgumentException("Appboy key is empty.");
+            throw new IllegalArgumentException("Braze key is empty.");
         }
 
         //try to get endpoint from the host setting
@@ -95,7 +95,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
             try {
                 this.enableTypeDetection = Boolean.parseBoolean(enableDetectionType);
             } catch (Exception e) {
-                Logger.warning("Appboy, unable to parse \"enableDetectionType\"");
+                Logger.warning("Braze, unable to parse \"enableDetectionType\"");
             }
         }
 
@@ -249,8 +249,8 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
                     BrazeProperties brazeProperties = new BrazeProperties(new JSONObject().put("Transaction ID", event.getTransactionAttributes().getId()).put("products", productArray));
                     Braze.getInstance(getContext()).logCustomEvent(eventList.get(0).getEventName(), brazeProperties);
                     messages.add(ReportingMessage.fromEvent(this, event));
-                } catch (Exception e) {
-                    Logger.warning("Failed to call logCustomEvent to Appboy kit: " + e.toString());
+                } catch (JSONException e) {
+                    Logger.warning("Failed to call logCustomEvent to Braze kit: " + e.toString());
                 }
             }
             queueDataFlush();

--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -242,6 +242,9 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
                 JSONArray productArray = new JSONArray();
                 for (int i = 0; i < eventList.size(); i++) {
                     Map<String, Object> newAttributes = eventList.get(i).getCustomAttributes();
+                    if (newAttributes == null) {
+                        newAttributes = new HashMap<>();
+                    }
                     newAttributes.put("custom attributes", event.getCustomAttributes());
                     productArray.put(newAttributes);
                 }

--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -427,6 +427,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
             }
         };
         CommerceEventUtils.extractActionAttributes(event, onAttributeExtracted);
+        purchaseProperties.addProperty("custom_attributes", event.getCustomAttributes());
 
         String currencyValue = currency[0];
         if (KitUtils.isEmpty(currencyValue)) {

--- a/src/main/java/com/mparticle/kits/AppboyKit.java
+++ b/src/main/java/com/mparticle/kits/AppboyKit.java
@@ -52,7 +52,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
 
     static final String APPBOY_KEY = "apiKey";
     static final String FORWARD_SCREEN_VIEWS = "forwardScreenViews";
-    static final String EXPAND_NON_PURCHASE_COMMERCE_EVENTS = "expandNonPurchaseCommerceEvents";
+    static final String BUNDLE_NON_PURCHASE_COMMERCE_EVENTS = "bundleNonPurchaseCommerceEvents";
     static final String USER_IDENTIFICATION_TYPE = "userIdentificationType";
     static final String ENABLE_TYPE_DETECTION = "enableTypeDetection";
 
@@ -67,7 +67,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
     private Runnable dataFlushRunnable;
     final private static int FLUSH_DELAY = 5000;
     private boolean forwardScreenViews = false;
-    private boolean expandNonPurchaseCommerceEvents = true;
+    private boolean bundleNonPurchaseCommerceEvents = false;
     boolean enableTypeDetection = false;
 
     public static boolean setDefaultAppboyLifecycleCallbackListener = true;
@@ -100,7 +100,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
         }
 
         forwardScreenViews = Boolean.parseBoolean(settings.get(FORWARD_SCREEN_VIEWS));
-        expandNonPurchaseCommerceEvents = Boolean.parseBoolean(settings.get(EXPAND_NON_PURCHASE_COMMERCE_EVENTS));
+        bundleNonPurchaseCommerceEvents = Boolean.parseBoolean(settings.get(BUNDLE_NON_PURCHASE_COMMERCE_EVENTS));
         BrazeConfig config = new BrazeConfig.Builder().setApiKey(key)
             .setSdkFlavor(SdkFlavor.MPARTICLE)
             .setSdkMetadata(EnumSet.of(BrazeSdkMetadata.MPARTICLE))
@@ -229,7 +229,7 @@ public class AppboyKit extends KitIntegration implements KitIntegration.Attribut
         }
         List<MPEvent> eventList = CommerceEventUtils.expand(event);
         if (eventList != null) {
-            if (expandNonPurchaseCommerceEvents) {
+            if (!bundleNonPurchaseCommerceEvents) {
                 for (int i = 0; i < eventList.size(); i++) {
                     try {
                         logEvent(eventList.get(i));


### PR DESCRIPTION
# Summary

For specific use cases such as abandoned cart, Braze must receive all products and associated product metadata within a single triggering event. This option can live within a config setting in the mP connection. 

Braze does not surface an native API to pass Purchase events with multiple products so Purchase events are omitted from this PR.

This PR also updates logging language from "Appboy" to "Braze" and includes custom attributes in Purchase events