### PR TITLE
fix: remove used library causing sonatype fail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,12 +13,10 @@ buildscript {
         classpath 'com.android.tools.build:gradle:7.2.1'
         classpath 'com.mparticle:android-kit-plugin:' + project.version
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
-
     }
 }
 apply plugin: "kotlin-android"
 apply plugin: 'com.mparticle.kit'
-
 
 android {
     defaultConfig {
@@ -28,7 +26,6 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
-
 }
 
 repositories {
@@ -37,11 +34,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'junit:junit:4.13.2'
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
     api 'com.appboy:android-sdk-ui:21.0.0'
     testImplementation  files('libs/java-json.jar')
-    implementation "androidx.core:core-ktx:+"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-
 }


### PR DESCRIPTION
## Summary
- remove used library causing sonatype fail

## Testing Plan
- regression tests should pass

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4377
