### PR TITLE
Add email_subscire and push_subscribe attribute functionality and fix

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -260,6 +260,8 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                 UserAttributes.MOBILE_NUMBER -> setPhoneNumber(value)
                 UserAttributes.ZIPCODE -> setCustomUserAttribute("Zip", value)
                 UserAttributes.AGE -> setDateOfBirth(key, value, user)
+                "email_subscribe" -> setEmailSubscriptionStatus(key, value, user)
+                "push_subscribe" -> setPushSubscriptionStatus(key, value, user)
                 "dob" -> useDobString(value, user)
                 UserAttributes.GENDER -> {
                     if (value.contains("fe")) setGender(Gender.FEMALE)
@@ -274,6 +276,32 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
             }
         }
         queueDataFlush()
+    }
+
+    private fun setEmailSubscriptionStatus(key: String, value: String, user: BrazeUser){
+        if (key == "email_subscribe") {
+            when (value) {
+                "opted_in" -> user.setEmailNotificationSubscriptionType(NotificationSubscriptionType.OPTED_IN)
+                "unsubscribed" -> user.setEmailNotificationSubscriptionType(NotificationSubscriptionType.UNSUBSCRIBED)
+                "subscribed" -> user.setEmailNotificationSubscriptionType(NotificationSubscriptionType.SUBSCRIBED)
+                else -> {
+                    Logger.error("unable to set email_subscribe with invalid value: " + value)
+                }
+            }
+        }
+    }
+
+    private fun setPushSubscriptionStatus(key: String, value: String, user: BrazeUser){
+        if (key == "push_subscribe") {
+            when (value) {
+                "opted_in" -> user.setPushNotificationSubscriptionType(NotificationSubscriptionType.OPTED_IN)
+                "unsubscribed" -> user.setPushNotificationSubscriptionType(NotificationSubscriptionType.UNSUBSCRIBED)
+                "subscribed" -> user.setPushNotificationSubscriptionType(NotificationSubscriptionType.SUBSCRIBED)
+                else -> {
+                    Logger.error("unable to set push_subscribe with invalid value: " + value)
+                }
+            }
+        }
     }
 
     private fun setDateOfBirth(key: String, value: String, user: BrazeUser) {


### PR DESCRIPTION
## Summary
A customer informed us that the email_subscribe and push_subscribe attribute assignment in Braze are not working per our [docs](https://docs.mparticle.com/integrations/braze/event/#user-attributes) stated. After further confirming and reproducing we also noticed that its the same case for the iOS integration as well and it was only working for the Web Braze kit.

## Testing Plan
Tested by importing the kit locally and applying the functions and changes in the code and sent the user attributes email_subscribe and push_subscribe with the values "opted_in", "subscribed" and "unsubscribed" and worked as expected by confirming in the Braze UI. Also, added logging when the value inputed is not one of the three values mentioned above and the error gets logged as expected

## More Info
A similar PR is also coming to the iOS Braze kit as well so stay tuned :)
