### PR TITLE
chore: bump android-sdk-ui from 23.3.0 to 24.3.0 and replace all com.appboy imports with com.braze

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
-    api 'com.appboy:android-sdk-ui:23.3.0'
+    api 'com.appboy:android-sdk-ui:24.2.0'
     testImplementation  files('libs/java-json.jar')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
-    api 'com.appboy:android-sdk-ui:24.2.0'
+    api 'com.appboy:android-sdk-ui:24.3.0'
     testImplementation  files('libs/java-json.jar')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-    id "org.sonarqube" version "4.0.0.2929"
+    id "org.sonarqube" version "3.5.0.2730"
     id "org.jlleitschuh.gradle.ktlint" version "11.2.0"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 }
 
 plugins {
-    id "org.sonarqube" version "3.5.0.2730"
+    id "org.sonarqube" version "4.0.0.2929"
     id "org.jlleitschuh.gradle.ktlint" version "11.2.0"
 }
 

--- a/consumer-proguard.pro
+++ b/consumer-proguard.pro
@@ -2,7 +2,7 @@
 
 -dontwarn com.amazon.device.messaging.**
 -dontwarn bo.app.**
--dontwarn com.appboy.ui.**
+-dontwarn com.braze.ui.**
 -dontwarn com.google.android.gms.**
 -keep class bo.app.** { *; }
--keep class com.appboy.** { *; }
+-keep class com.braze.** { *; }

--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -5,10 +5,10 @@ import android.app.Application.ActivityLifecycleCallbacks
 import android.content.Context
 import android.content.Intent
 import android.os.Handler
-import com.appboy.enums.Gender
-import com.appboy.enums.Month
-import com.appboy.enums.SdkFlavor
-import com.appboy.enums.NotificationSubscriptionType
+import com.braze.enums.Gender
+import com.braze.enums.Month
+import com.braze.enums.SdkFlavor
+import com.braze.enums.NotificationSubscriptionType
 import com.braze.Braze
 import com.braze.BrazeActivityLifecycleCallbackListener
 import com.braze.BrazeUser

--- a/src/test/kotlin/com/braze/BrazeUser.kt
+++ b/src/test/kotlin/com/braze/BrazeUser.kt
@@ -1,6 +1,6 @@
 package com.braze
 
-import com.appboy.enums.Month
+import com.braze.enums.Month
 import java.util.HashMap
 import java.util.ArrayList
 import java.lang.NullPointerException

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -1,6 +1,6 @@
 package com.mparticle.kits
 
-import com.appboy.enums.Month
+import com.braze.enums.Month
 import com.braze.Braze
 import com.mparticle.MPEvent
 import com.mparticle.MParticle


### PR DESCRIPTION
 ## Summary
Fixes https://github.com/mparticle-integrations/mparticle-android-integration-appboy/pull/115, https://github.com/mparticle-integrations/mparticle-android-integration-appboy/pull/128 and addresses https://github.com/mparticle-integrations/mparticle-android-integration-appboy/issues/117

The Braze Android SDK v24 replaced the `com.appboy` classpath with `com.braze` as [outlined in the changelog](https://github.com/Appboy/appboy-android-sdk/commit/443b232c545d5127bca0cd36001b5b421385a119).

Currently, this mParticle kit still looks for `com.appboy` which crashes the app. This PR fixes it by replacing all `com.appboy` imports with their `com.braze` equivalents.

|old import|replaced by|
|---|---|
|`com.appboy.enums.Gender`|`com.braze.enums.Gender`|
|`com.appboy.enums.Month`|`com.braze.enums.Month`|
|`com.appboy.enums.SdkFlavor`|`com.braze.enums.SdkFlavor`|
|`com.appboy.enums.NotificationSubscriptionType`|`com.braze.enums.NotificationSubscriptionType`|

 ## Testing Plan
 - Ran test suite locally. All tests passed.
 - Compiled a local artifact `android-appboy-kit-release.aar` and impoted that locally. Everything works OK.
