### PR TITLE
chore: bump android-sdk-ui from 24.3.0 to 25.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,11 @@ android {
 }
 
 repositories {
-    maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
     mavenCentral()
 }
 
 dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
-    api 'com.appboy:android-sdk-ui:24.3.0'
+    api 'com.braze:android-sdk-ui:25.0.0'
     testImplementation  files('libs/java-json.jar')
 }


### PR DESCRIPTION
 ## Summary

The recently released [Braze Android SDK v25](https://github.com/braze-inc/braze-android-sdk/blob/master/CHANGELOG.md#2500) is now hosted on Maven Central which means that

```groovy
repositories {
  maven { url "https://appboy.github.io/appboy-android-sdk/sdk" }
}
```

can now be removed from `build.gradle`.

Also, the dependency name has been renamed from

```groovy
 'com.appboy:android-sdk-ui'
```

to

```groovy
 'com.braze:android-sdk-ui'
```

 ## Testing Plan
- Ran test suite locally. All tests passed.
- Tested using a locally built artifact `android-appboy-kit-release.aar`. Works OK.

