### PR TITLE
feat: add order level commerce events

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -68,12 +68,12 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                 Logger.warning("Braze, unable to parse \"enableDetectionType\"")
             }
         }
-        val forwardEnhanced = settings[BUNDLE_PRODUCTS_WITH_COMMERCE_EVENTS]
-        if (!KitUtils.isEmpty(forwardEnhanced)) {
+        val bundleProducts = settings[BUNDLE_PRODUCTS_WITH_COMMERCE_EVENTS]
+        if (!KitUtils.isEmpty(bundleProducts)) {
             try {
-                bundleProductsWithCommerceEvents = forwardEnhanced.toBoolean()
+                bundleProductsWithCommerceEvents = bundleProducts.toBoolean()
             } catch (e: Exception) {
-                Logger.warning("Braze, unable to parse \"forwardEnhanced\"")
+                bundleProductsWithCommerceEvents = false
             }
         }
         forwardScreenViews = settings[FORWARD_SCREEN_VIEWS].toBoolean()
@@ -206,7 +206,6 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
             if (bundleProductsWithCommerceEvents) {
                 logOrderLevelTransaction(event)
                 messages.add(ReportingMessage.fromEvent(this, event))
-                queueDataFlush()
             } else {
                 val productList = event.products
                 productList?.let {
@@ -216,12 +215,10 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                 }
             }
             messages.add(ReportingMessage.fromEvent(this, event))
-            queueDataFlush()
         } else {
             if (bundleProductsWithCommerceEvents) {
                 logOrderLevelTransaction(event)
                 messages.add(ReportingMessage.fromEvent(this, event))
-                queueDataFlush()
             } else {
                 val eventList = CommerceEventUtils.expand(event)
                 if (eventList != null) {
@@ -233,10 +230,10 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                             Logger.warning("Failed to call logCustomEvent to Appboy kit: $e")
                         }
                     }
-                    queueDataFlush()
                 }
             }
         }
+        queueDataFlush()
         return messages
     }
 
@@ -723,16 +720,16 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         val promotionArray = arrayOfNulls<BrazeProperties>(promotionList.count())
         for ((i, promotion) in promotionList.withIndex()) {
             val promotionProperties = BrazeProperties()
-            promotion.creative.let {
+            promotion.creative?.let {
                 promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_CREATIVE, it)
             }
-            promotion.id.let {
+            promotion.id?.let {
                 promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_ID, it)
             }
-            promotion.name.let {
+            promotion.name?.let {
                 promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_NAME, it)
             }
-            promotion.position.let {
+            promotion.position?.let {
                 promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_POSITION, it)
             }
             promotionArray[i] = promotionProperties
@@ -744,10 +741,10 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         val impressionArray = arrayOfNulls<BrazeProperties>(impressionList.count())
         for ((i, impression) in impressionList.withIndex()) {
             val impressionProperties = BrazeProperties()
-            impression.listName.let {
+            impression.listName?.let {
                 impressionProperties.addProperty("Product Impression List", it)
             }
-            impression.products.let {
+            impression.products?.let {
                 val productArray = getProductListParameters(it)
                 impressionProperties.addProperty(PRODUCT_KEY, productArray)
             }
@@ -873,7 +870,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         private const val UNSUBSCRIBED = "unsubscribed"
         private const val SUBSCRIBED = "subscribed"
 
-        private const val CUSTOM_ATTRIBUTES_KEY = "custom_attributes"
+        private const val CUSTOM_ATTRIBUTES_KEY = "Attributes"
         const val PRODUCT_KEY = "products"
         const val PROMOTION_KEY = "promotions"
         const val IMPRESSION_KEY = "impressions"

--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -470,9 +470,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         }
 
         event?.customAttributes?.let {
-            for ((key, value) in it) {
-                properties.addProperty(key, value)
-            }
+            properties.addProperty(CUSTOM_ATTRIBUTES_KEY, it)
         }
 
         val productList = event?.products
@@ -870,7 +868,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         private const val UNSUBSCRIBED = "unsubscribed"
         private const val SUBSCRIBED = "subscribed"
 
-        private const val CUSTOM_ATTRIBUTES_KEY = "Attributes"
+        const val CUSTOM_ATTRIBUTES_KEY = "Attributes"
         const val PRODUCT_KEY = "products"
         const val PROMOTION_KEY = "promotions"
         const val IMPRESSION_KEY = "impressions"

--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -5,15 +5,11 @@ import android.app.Application.ActivityLifecycleCallbacks
 import android.content.Context
 import android.content.Intent
 import android.os.Handler
-import com.braze.enums.Gender
-import com.braze.enums.Month
-import com.braze.enums.SdkFlavor
-import com.braze.enums.NotificationSubscriptionType
 import com.braze.Braze
 import com.braze.BrazeActivityLifecycleCallbackListener
 import com.braze.BrazeUser
 import com.braze.configuration.BrazeConfig
-import com.braze.enums.BrazeSdkMetadata
+import com.braze.enums.*
 import com.braze.models.outgoing.BrazeProperties
 import com.braze.push.BrazeFirebaseMessagingService
 import com.braze.push.BrazeNotificationUtils.isBrazePushMessage
@@ -23,13 +19,11 @@ import com.mparticle.MParticle.IdentityType
 import com.mparticle.MParticle.UserAttributes
 import com.mparticle.commerce.CommerceEvent
 import com.mparticle.commerce.Product
+import com.mparticle.commerce.Promotion
 import com.mparticle.identity.MParticleUser
 import com.mparticle.internal.Logger
 import com.mparticle.kits.CommerceEventUtils.OnAttributeExtracted
 import com.mparticle.kits.KitIntegration.*
-import org.json.JSONArray
-import org.json.JSONException
-import org.json.JSONObject
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util.*
@@ -41,6 +35,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
     KitIntegration.EventListener, PushListener, IdentityListener {
 
     var enableTypeDetection = false
+    var bundleProductsWithCommerceEvents = false
     var isMpidIdentityType = false
     var identityType: IdentityType? = null
     private val dataFlushHandler = Handler()
@@ -70,6 +65,14 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                 enableTypeDetection = enableDetectionType.toBoolean()
             } catch (e: Exception) {
                 Logger.warning("Braze, unable to parse \"enableDetectionType\"")
+            }
+        }
+        val forwardEnhanced = settings[BUNDLE_PRODUCTS_WITH_COMMERCE_EVENTS]
+        if (!KitUtils.isEmpty(forwardEnhanced)) {
+            try {
+                bundleProductsWithCommerceEvents = forwardEnhanced.toBoolean()
+            } catch (e: Exception) {
+                Logger.warning("Braze, unable to parse \"forwardEnhanced\"")
             }
         }
         forwardScreenViews = settings[FORWARD_SCREEN_VIEWS].toBoolean()
@@ -199,27 +202,39 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                 true
             ) && !event.products.isNullOrEmpty()
         ) {
-            val productList = event.products
-            productList?.let {
-                for (product in productList) {
-                    logTransaction(event, product)
+            if (bundleProductsWithCommerceEvents) {
+                logOrderLevelTransaction(event)
+                messages.add(ReportingMessage.fromEvent(this, event))
+                queueDataFlush()
+            } else {
+                val productList = event.products
+                productList?.let {
+                    for (product in productList) {
+                        logTransaction(event, product)
+                    }
                 }
             }
             messages.add(ReportingMessage.fromEvent(this, event))
             queueDataFlush()
-            return messages
-        }
-        val eventList = CommerceEventUtils.expand(event)
-        if (eventList != null) {
-            for (i in eventList.indices) {
-                try {
-                    logEvent(eventList[i])
-                    messages.add(ReportingMessage.fromEvent(this, event))
-                } catch (e: Exception) {
-                    Logger.warning("Failed to call logCustomEvent to Appboy kit: $e")
+        } else {
+            if (bundleProductsWithCommerceEvents) {
+                logOrderLevelTransaction(event)
+                messages.add(ReportingMessage.fromEvent(this, event))
+                queueDataFlush()
+            } else {
+                val eventList = CommerceEventUtils.expand(event)
+                if (eventList != null) {
+                    for (i in eventList.indices) {
+                        try {
+                            logEvent(eventList[i])
+                            messages.add(ReportingMessage.fromEvent(this, event))
+                        } catch (e: Exception) {
+                            Logger.warning("Failed to call logCustomEvent to Appboy kit: $e")
+                        }
+                    }
+                    queueDataFlush()
                 }
             }
-            queueDataFlush()
         }
         return messages
     }
@@ -411,6 +426,91 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         )
     }
 
+    fun logOrderLevelTransaction(event: CommerceEvent?) {
+        val properties = BrazeProperties()
+        val currency = arrayOfNulls<String>(1)
+        val commerceTypeParser: StringTypeParser =
+            BrazePropertiesSetter(properties, enableTypeDetection)
+        val onAttributeExtracted: OnAttributeExtracted = object : OnAttributeExtracted {
+            override fun onAttributeExtracted(key: String, value: String) {
+                if (!checkCurrency(key, value)) {
+                    commerceTypeParser.parseValue(key, value)
+                }
+            }
+
+            override fun onAttributeExtracted(key: String, value: Double) {
+                if (!checkCurrency(key, value)) {
+                    properties.addProperty(key, value)
+                }
+            }
+
+            override fun onAttributeExtracted(key: String, value: Int) {
+                properties.addProperty(key, value)
+            }
+
+            override fun onAttributeExtracted(attributes: Map<String, String>) {
+                for ((key, value) in attributes) {
+                    if (!checkCurrency(key, value)) {
+                        commerceTypeParser.parseValue(key, value)
+                    }
+                }
+            }
+
+            private fun checkCurrency(key: String, value: Any?): Boolean {
+                return if (CommerceEventUtils.Constants.ATT_ACTION_CURRENCY_CODE == key) {
+                    currency[0] = value?.toString()
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+        CommerceEventUtils.extractActionAttributes(event, onAttributeExtracted)
+        var currencyValue = currency[0]
+        if (KitUtils.isEmpty(currencyValue)) {
+            currencyValue = CommerceEventUtils.Constants.DEFAULT_CURRENCY_CODE
+        }
+
+        event?.customAttributes?.let {
+            for ((key, value) in it) {
+                properties.addProperty(key, value)
+            }
+        }
+
+        val productList = event?.products
+        productList?.let {
+            val productArray = getProductListParameters(it)
+            properties.addProperty(PRODUCT_KEY, productArray)
+        }
+
+        val promotionList = event?.promotions
+        promotionList?.let {
+            val promotionArray = getPromotionListParameters(it)
+            properties.addProperty(PROMOTION_KEY, promotionArray)
+        }
+
+        val eventName = "eCommerce - %s"
+        if (!KitUtils.isEmpty(event?.productAction) &&
+            event?.productAction.equals(Product.PURCHASE,true)
+        ) {
+            Braze.Companion.getInstance(context).logPurchase(
+                String.format(eventName, event?.productAction),
+                currencyValue,
+                event?.transactionAttributes?.revenue?.let { BigDecimal(it) } ?: BigDecimal(0),
+                1,
+                properties
+            )
+        } else {
+            if (!KitUtils.isEmpty(event?.productAction)) {
+                Braze.getInstance(context).logCustomEvent(String.format(eventName, event?.productAction), properties)
+            } else if (!KitUtils.isEmpty(event?.promotionAction)) {
+                Braze.getInstance(context).logCustomEvent(String.format(eventName, event?.promotionAction), properties)
+            } else {
+                Braze.getInstance(context).logCustomEvent(String.format(eventName, "unknown"), properties)
+            }
+        }
+    }
+
     override fun willHandlePushMessage(intent: Intent): Boolean {
         return if (!(settings[PUSH_ENABLED].toBoolean())) {
             false
@@ -562,6 +662,77 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         }
     }
 
+    fun getProductListParameters(productList: List<Product>): Array<BrazeProperties?> {
+        val productArray = arrayOfNulls<BrazeProperties>(productList.count())
+        for ((i, product) in productList.withIndex()) {
+            val productProperties = BrazeProperties()
+
+            product.customAttributes?.let {
+                productProperties.addProperty(CUSTOM_ATTRIBUTES_KEY, it)
+            }
+            product.couponCode?.let {
+                productProperties.addProperty(
+                    CommerceEventUtils.Constants.ATT_PRODUCT_COUPON_CODE,
+                    it
+                )
+            }
+            product.brand?.let {
+                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_BRAND, it)
+            }
+            product.category?.let {
+                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_CATEGORY, it)
+            }
+            product.name?.let {
+                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_NAME, it)
+            }
+            product.sku?.let {
+                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_ID, it)
+            }
+            product.variant?.let {
+                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_VARIANT, it)
+            }
+            product.position?.let {
+                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_POSITION, it)
+            }
+            productProperties.addProperty(
+                CommerceEventUtils.Constants.ATT_PRODUCT_PRICE,
+                product.unitPrice
+            )
+            productProperties.addProperty(
+                CommerceEventUtils.Constants.ATT_PRODUCT_QUANTITY,
+                product.quantity
+            )
+            productProperties.addProperty(
+                CommerceEventUtils.Constants.ATT_PRODUCT_TOTAL_AMOUNT,
+                product.totalAmount
+            )
+
+            productArray[i] = productProperties
+        }
+        return productArray
+    }
+
+    fun getPromotionListParameters(promotionList: List<Promotion>): Array<BrazeProperties?> {
+        val promotionArray = arrayOfNulls<BrazeProperties>(promotionList.count())
+        for ((i, promotion) in promotionList.withIndex()) {
+            val promotionProperties = BrazeProperties()
+            promotion.creative.let {
+                promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_CREATIVE, it)
+            }
+            promotion.id.let {
+                promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_ID, it)
+            }
+            promotion.name.let {
+                promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_NAME, it)
+            }
+            promotion.position.let {
+                promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_POSITION, it)
+            }
+            promotionArray[i] = promotionProperties
+        }
+        return promotionArray
+    }
+
     internal abstract class StringTypeParser(var enableTypeDetection: Boolean) {
         fun parseValue(key: String, value: String): Any {
             if (!enableTypeDetection) {
@@ -662,6 +833,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         const val FORWARD_SCREEN_VIEWS = "forwardScreenViews"
         const val USER_IDENTIFICATION_TYPE = "userIdentificationType"
         const val ENABLE_TYPE_DETECTION = "enableTypeDetection"
+        const val BUNDLE_PRODUCTS_WITH_COMMERCE_EVENTS = "bundleProductsWithCommerceEvents"
         const val HOST = "host"
         const val PUSH_ENABLED = "push_enabled"
         const val NAME = "Appboy"
@@ -677,5 +849,9 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         private const val OPTED_IN = "opted_in"
         private const val UNSUBSCRIBED = "unsubscribed"
         private const val SUBSCRIBED = "subscribed"
+
+        private const val CUSTOM_ATTRIBUTES_KEY = "custom_attributes"
+        const val PRODUCT_KEY = "products"
+        const val PROMOTION_KEY = "promotions"
     }
 }

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -525,13 +525,20 @@ class AppboyKitTests {
             properties.remove(CommerceEventUtils.Constants.ATT_TRANSACTION_ID),
             "the id"
         )
-        Assert.assertEquals(properties.remove("key1"), "value1")
-        Assert.assertEquals(properties.remove("key #2"), "value #3")
+
+        val brazeCustomAttributesDictionary = properties.remove(AppboyKit.CUSTOM_ATTRIBUTES_KEY)
+        if (brazeCustomAttributesDictionary is BrazeProperties) {
+            val customAttributesDictionary = brazeCustomAttributesDictionary.properties
+            Assert.assertEquals(customAttributesDictionary.remove("key1"), "value1")
+            Assert.assertEquals(customAttributesDictionary.remove("key #2"), "value #3")
+            Assert.assertEquals(emptyAttributes, customAttributesDictionary)
+        }
         Assert.assertEquals(emptyAttributes, properties)
     }
 
     @Test
     fun testPromotion() {
+        val emptyAttributes = HashMap<String, String>()
         val kit = MockAppboyKit()
         kit.configuration = MockKitConfiguration()
         val customAttributes = HashMap<String, String>()
@@ -562,7 +569,6 @@ class AppboyKitTests {
         Assert.assertEquals(properties.remove("key1"), "value1")
         Assert.assertEquals(properties.remove("key #2"), "value #3")
 
-        val emptyAttributes = HashMap<String, String>()
         Assert.assertEquals(emptyAttributes, properties)
     }
 
@@ -606,8 +612,14 @@ class AppboyKitTests {
             }
         }
 
-        Assert.assertEquals(properties.remove("key1"), "value1")
-        Assert.assertEquals(properties.remove("key #2"), "value #3")
+        val brazeCustomAttributesDictionary = properties.remove(AppboyKit.CUSTOM_ATTRIBUTES_KEY)
+        if (brazeCustomAttributesDictionary is BrazeProperties) {
+            val customAttributesDictionary = brazeCustomAttributesDictionary.properties
+            Assert.assertEquals(customAttributesDictionary.remove("key1"), "value1")
+            Assert.assertEquals(customAttributesDictionary.remove("key #2"), "value #3")
+            Assert.assertEquals(emptyAttributes, customAttributesDictionary)
+        }
+
         Assert.assertEquals(properties.remove(CommerceEventUtils.Constants.ATT_TOTAL), 0.0)
 
         Assert.assertEquals(emptyAttributes, properties)
@@ -662,6 +674,7 @@ class AppboyKitTests {
         customAttributes["key #2"] = "value #3"
         val product = Product.Builder("product name", "sku1", 4.5)
             .quantity(5.0)
+            .customAttributes(customAttributes)
             .build()
         val impression = Impression("Suggested Products List", product).let {
             CommerceEvent.Builder(it).build()
@@ -712,6 +725,13 @@ class AppboyKitTests {
                             productProperties.remove(CommerceEventUtils.Constants.ATT_PRODUCT_PRICE),
                             4.5
                         )
+                        val brazeProductCustomAttributesDictionary = productProperties.remove(AppboyKit.CUSTOM_ATTRIBUTES_KEY)
+                        if (brazeProductCustomAttributesDictionary is BrazeProperties) {
+                            val customProductAttributesDictionary = brazeProductCustomAttributesDictionary.properties
+                            Assert.assertEquals(customProductAttributesDictionary.remove("key1"), "value1")
+                            Assert.assertEquals(customProductAttributesDictionary.remove("key #2"), "value #3")
+                            Assert.assertEquals(emptyAttributes, customProductAttributesDictionary)
+                        }
                         Assert.assertEquals(emptyAttributes, productProperties)
                     }
                     Assert.assertEquals(emptyAttributes, impressionProperties)
@@ -719,8 +739,14 @@ class AppboyKitTests {
             }
         }
 
-        Assert.assertEquals(properties.remove("key1"), "value1")
-        Assert.assertEquals(properties.remove("key #2"), "value #3")
+        val brazeCustomAttributesDictionary = properties.remove(AppboyKit.CUSTOM_ATTRIBUTES_KEY)
+        if (brazeCustomAttributesDictionary is BrazeProperties) {
+            val customAttributesDictionary = brazeCustomAttributesDictionary.properties
+            Assert.assertEquals(customAttributesDictionary.remove("key1"), "value1")
+            Assert.assertEquals(customAttributesDictionary.remove("key #2"), "value #3")
+            Assert.assertEquals(emptyAttributes, customAttributesDictionary)
+        }
+
         Assert.assertEquals(properties.remove(CommerceEventUtils.Constants.ATT_TOTAL), 0.0)
 
         Assert.assertEquals(emptyAttributes, properties)

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -546,12 +546,8 @@ class AppboyKitTests {
         val commerceEvent = CommerceEvent.Builder(Promotion.VIEW, promotion)
             .customAttributes(customAttributes)
             .build()
-        val eventList = CommerceEventUtils.expand(commerceEvent)
-        Assert.assertEquals(1, eventList.size.toLong())
+        kit.logEvent(commerceEvent)
 
-        eventList?.forEach {
-            kit.logEvent(it)
-        }
         val braze = Braze
         val events = braze.events
         Assert.assertEquals(1, events.size.toLong())
@@ -633,12 +629,9 @@ class AppboyKitTests {
         val commerceEvent = CommerceEvent.Builder(impression)
             .customAttributes(customAttributes)
             .build()
-        val eventList = CommerceEventUtils.expand(commerceEvent)
-        Assert.assertEquals(1, eventList.size.toLong())
 
-        eventList?.forEach {
-            kit.logEvent(it)
-        }
+        kit.logEvent(commerceEvent)
+
         val braze = Braze
         val events = braze.events
         Assert.assertEquals(1, events.size.toLong())


### PR DESCRIPTION
 ## Summary
 - All commerce events (both purchase and non-purchase events) forwarded to Braze as a single event with products nested in event properties when bundleProductsWithCommerceEvents set to true.
- All commerce events (both purchase and non-purchase events) forwarded to Braze as expanded individual events for each product when bundleProductsWithCommerceEvents set to false.

 ## Testing Plan
 - Tested locally and through unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5428
