### PR TITLE
fix: Forward Custom Attributes for all Commerce Events

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -451,6 +451,13 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         if (KitUtils.isEmpty(currencyValue)) {
             currencyValue = CommerceEventUtils.Constants.DEFAULT_CURRENCY_CODE
         }
+
+        event?.customAttributes?.let {
+            for ((key, value) in it) {
+                purchaseProperties.addProperty(key, value)
+            }
+        }
+
         Braze.Companion.getInstance(context).logPurchase(
             product.sku,
             currencyValue,

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -449,6 +449,11 @@ class AppboyKitTests {
             properties.remove(CommerceEventUtils.Constants.ATT_AFFILIATION),
             "the affiliation"
         )
+
+        //Custom Attributes
+        Assert.assertEquals(properties.remove("key1"), "value1")
+        Assert.assertEquals(properties.remove("key #2"), "value #3")
+
         val emptyAttributes = HashMap<String, String>()
         Assert.assertEquals(emptyAttributes, properties)
     }


### PR DESCRIPTION
## Summary
 - An earlier revert undid support for Custom Attributes for purchase events so when it was added for non-purchase events that regression was discovered

 ## Testing Plan
 - Tested locally and through unit tests

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5170
