### PR TITLE
Fix/supports attribute lists

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -347,7 +347,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         })
     }
 
-    override fun supportsAttributeLists(): Boolean = false
+    override fun supportsAttributeLists(): Boolean = true
 
     protected open fun queueDataFlush() {
         dataFlushRunnable?.let { dataFlushHandler.removeCallbacks(it) }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - set the supportsAttributeLists function override to return true 

 ## Testing Plan
- No, this flag was previous set to true before the kotlin port and was mistakenly set to false after.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 https://mparticle-eng.atlassian.net/browse/SQDSDKS-5838
