### PR TITLE
fix: flip supportsAttributeLists back to true

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -347,7 +347,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         })
     }
 
-    override fun supportsAttributeLists(): Boolean = false
+    override fun supportsAttributeLists(): Boolean = true
 
     protected open fun queueDataFlush() {
         dataFlushRunnable?.let { dataFlushHandler.removeCallbacks(it) }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - change override function supportsAttributeLists to return true

 ## Testing Plan
 - No, flag was previously set to true and was changed mistakenly to false

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - (https://mparticle-eng.atlassian.net/browse/SQDSDKS-5838)