### PR TITLE
fix: implement new audience api in test mock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,11 @@ android {
         sourceCompatibility 1.8
         targetCompatibility 1.8
     }
+    testOptions {
+        unitTests.all {
+            jvmArgs += ['--add-opens', 'java.base/java.lang=ALL-UNNAMED']
+        }
+    }
 }
 
 repositories {

--- a/src/test/kotlin/com/mparticle/kits/mocks/MockUser.kt
+++ b/src/test/kotlin/com/mparticle/kits/mocks/MockUser.kt
@@ -1,8 +1,9 @@
 package com.mparticle.kits.mocks
 
 import com.mparticle.MParticle.IdentityType
-import com.mparticle.UserAttributeListener
 import com.mparticle.UserAttributeListenerType
+import com.mparticle.audience.AudienceResponse
+import com.mparticle.audience.AudienceTask
 import com.mparticle.identity.MParticleUser
 import com.mparticle.consent.ConsentState
 
@@ -37,5 +38,10 @@ class MockUser(var identities: Map<IdentityType, String>) : MParticleUser {
     override fun getFirstSeenTime(): Long = 0
 
     override fun getLastSeenTime(): Long = 0
+
+    override fun getUserAudiences(): AudienceTask<AudienceResponse> {
+        throw NotImplementedError("getUserAudiences() is not implemented")
+    }
+
 
 }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Fix Kit Compatibility Test, added getUserAudiences method

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Verified through compilation of a local application.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6131
