### PR TITLE
fix: Add enum value to hash event attributes

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -152,7 +152,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                     event.customAttributeStrings?.let { it ->
                         for ((key, attributeValue) in it) {
                             val hashedKey =
-                                KitUtils.hashForFiltering(event.eventType.toString() + event.eventName + key)
+                                KitUtils.hashForFiltering(event.eventType.value.toString() + event.eventName + key)
 
                             configuration.eventAttributesAddToUser?.get(hashedKey)?.let {
                                 value.addToCustomAttributeArray(it, attributeValue)

--- a/src/test/kotlin/com/braze/Braze.kt
+++ b/src/test/kotlin/com/braze/Braze.kt
@@ -2,6 +2,7 @@ package com.braze
 
 import android.content.Context
 import com.braze.configuration.BrazeConfig
+import com.braze.events.IValueCallback
 import com.braze.models.outgoing.BrazeProperties
 import com.mparticle.kits.BrazePurchase
 import java.math.BigDecimal
@@ -12,8 +13,19 @@ class Braze {
         return Companion.currentUser
     }
 
+    fun getCustomAttributeArray(): java.util.HashMap<String, MutableList<String>> {
+        return Companion.currentUser.getCustomAttribute()
+    }
+
+    fun getCurrentUser(callback: IValueCallback<BrazeUser>) {
+        callback.onSuccess(currentUser)
+    }
     fun logCustomEvent(key: String, brazeProperties: BrazeProperties) {
         events[key] = brazeProperties
+    }
+
+    fun logCustomEvent(key: String) {
+        events[key] = BrazeProperties()
     }
 
     fun logPurchase(

--- a/src/test/kotlin/com/braze/BrazeUser.kt
+++ b/src/test/kotlin/com/braze/BrazeUser.kt
@@ -32,7 +32,9 @@ class BrazeUser {
 
     fun removeFromCustomAttributeArray(key: String, value: String): Boolean {
         return try {
-            customAttributeArray[key]?.remove(value)
+            if (customAttributeArray.containsKey(key)) {
+                customAttributeArray.remove(key)
+            }
             true
         } catch (npe: NullPointerException) {
             false
@@ -57,5 +59,12 @@ class BrazeUser {
     fun setCustomUserAttribute(key: String, value: Double): Boolean {
         customUserAttributes[key] = value
         return true
+    }
+    fun getCustomAttribute(): HashMap<String, MutableList<String>> {
+        return customAttributeArray
+    }
+
+    fun getCustomUserAttribute(): HashMap<String, Any> {
+        return customUserAttributes
     }
 }

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -1,5 +1,6 @@
 package com.mparticle.kits
 
+import android.util.SparseBooleanArray
 import com.braze.enums.Month
 import com.braze.Braze
 import com.braze.models.outgoing.BrazeProperties
@@ -21,10 +22,13 @@ import com.mparticle.kits.mocks.MockAppboyKit
 import com.mparticle.kits.mocks.MockContextApplication
 import com.mparticle.kits.mocks.MockKitConfiguration
 import com.mparticle.kits.mocks.MockUser
+import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mock
 import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
 import java.math.BigDecimal
 import java.util.Calendar
 import java.util.Locale
@@ -32,19 +36,28 @@ import java.util.Random
 
 class AppboyKitTests {
     private var random = Random()
+
+    private lateinit var braze: Braze.Companion
+
+    @Mock
+    private val mTypeFilters: SparseBooleanArray? = null
+
     private val kit: AppboyKit
         get() = AppboyKit()
 
     @Before
     fun setup() {
+        MockitoAnnotations.initMocks(this)
+        Braze.clearPurchases()
+        Braze.clearEvents()
         MParticle.setInstance(Mockito.mock(MParticle::class.java))
         Mockito.`when`(MParticle.getInstance()!!.Identity()).thenReturn(
             Mockito.mock(
                 IdentityApi::class.java
             )
         )
-        Braze.clearPurchases()
-        Braze.clearEvents()
+        braze = Braze
+        braze.currentUser.getCustomAttribute().clear()
     }
 
     @Test
@@ -927,4 +940,110 @@ class AppboyKitTests {
 //        Assert.assertEquals(properties.remove("fuzz?"), "foobar")
 //        Assert.assertEquals(0, properties.size.toLong())
 //    }
+
+    @Test
+    fun testCustomAttributes_log_add_attribute_event() {
+        val kit = MockAppboyKit()
+        val currentUser = braze.currentUser
+
+        kit.configuration = MockKitConfiguration()
+
+        val jsonObject = JSONObject()
+        val mapValue = JSONObject()
+        //this is hash for event attribute i.e combination of eventType + eventName + attribute key
+        mapValue.put("888169310", "testEvent")
+        val eaaObject = JSONObject()
+        eaaObject.put("eaa", mapValue)
+        jsonObject.put("hs", eaaObject)
+
+        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0)
+
+        var kitConfiguration = MockKitConfiguration.createKitConfiguration(jsonObject)
+        kit.configuration = kitConfiguration
+        val customAttributes: MutableMap<String, String> = HashMap()
+        customAttributes["destination"] = "Shop"
+        val event = MPEvent.Builder("AndroidTEST", MParticle.EventType.Navigation)
+            .customAttributes(customAttributes)
+            .build()
+        val instance = MParticle.getInstance()
+        instance?.logEvent(event)
+        kit.logEvent(event)
+        Assert.assertEquals(1, braze.events.size.toLong())
+        Assert.assertEquals(1, currentUser.getCustomAttribute().size.toLong())
+        var outputKey = ""
+        for (keys in currentUser.getCustomAttribute().keys) {
+            outputKey = keys
+            break
+        }
+        Assert.assertEquals("testEvent", outputKey)
+    }
+
+    @Test
+    fun testCustomAttributes_log_remove_attribute_event() {
+        val kit = MockAppboyKit()
+        val currentUser = braze.currentUser
+
+        kit.configuration = MockKitConfiguration()
+
+        val jsonObject = JSONObject()
+        val mapValue = JSONObject()
+        //this is hash for event attribute i.e combination of eventType + eventName + attribute key
+        mapValue.put("888169310", "testEvent")
+        val eaaObject = JSONObject()
+        eaaObject.put("eaa", mapValue)
+        eaaObject.put("ear", mapValue)
+        jsonObject.put("hs", eaaObject)
+
+        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0)
+
+        var kitConfiguration = MockKitConfiguration.createKitConfiguration(jsonObject)
+        kit.configuration = kitConfiguration
+        val customAttributes: MutableMap<String, String> = HashMap()
+        customAttributes["destination"] = "Shop"
+        val event = MPEvent.Builder("AndroidTEST", MParticle.EventType.Navigation)
+            .customAttributes(customAttributes)
+            .build()
+        val instance = MParticle.getInstance()
+        instance?.logEvent(event)
+        kit.logEvent(event)
+        Assert.assertEquals(1, braze.events.size.toLong())
+        Assert.assertEquals(0, currentUser.getCustomAttribute().size.toLong())
+    }
+
+    @Test
+    fun testCustomAttributes_log_add_customUserAttribute_event() {
+        val kit = MockAppboyKit()
+        val currentUser = braze.currentUser
+
+        kit.configuration = MockKitConfiguration()
+
+        val jsonObject = JSONObject()
+        val mapValue = JSONObject()
+        //this is hash for event attribute i.e combination of eventType + eventName + attribute key
+        mapValue.put("888169310", "testEvent")
+        val eaaObject = JSONObject()
+        eaaObject.put("eas", mapValue)
+        jsonObject.put("hs", eaaObject)
+
+        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0)
+
+        var kitConfiguration = MockKitConfiguration.createKitConfiguration(jsonObject)
+        kit.configuration = kitConfiguration
+        val customAttributes: MutableMap<String, String> = HashMap()
+        customAttributes["destination"] = "Shop"
+        val event = MPEvent.Builder("AndroidTEST", MParticle.EventType.Navigation)
+            .customAttributes(customAttributes)
+            .build()
+        val instance = MParticle.getInstance()
+        instance?.logEvent(event)
+        kit.logEvent(event)
+        Assert.assertEquals(1, braze.events.size.toLong())
+        Assert.assertEquals(1, currentUser.getCustomUserAttribute().size.toLong())
+        var outputKey = ""
+        for (keys in currentUser.getCustomUserAttribute().keys) {
+            outputKey = keys
+            break
+        }
+        Assert.assertEquals("testEvent", outputKey)
+    }
 }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Use enum values to create hash for event attributes instead of using a enum.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample application and executed unit test cases

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6544
