### PR TITLE
fix: Add enum value to hash ecommerce event attributes

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -142,7 +142,11 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
             val brazePropertiesSetter = BrazePropertiesSetter(properties, enableTypeDetection)
             event.customAttributeStrings?.let { it ->
                 for ((key, value) in it) {
-                    newAttributes[key] = brazePropertiesSetter.parseValue(key, value)
+                    try {
+                        newAttributes[key] = brazePropertiesSetter.parseValue(key, value)
+                    } catch (e: Exception) {
+                        Logger.warning("Exception while parsing custom attributes $e")
+                    }
                 }
             }
             Braze.getInstance(context).logCustomEvent(event.eventName, properties)
@@ -152,7 +156,11 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                     event.customAttributeStrings?.let { it ->
                         for ((key, attributeValue) in it) {
                             val hashedKey =
-                                KitUtils.hashForFiltering(event.eventType.value.toString() + event.eventName + key)
+                                if (event.eventName.contains("eCommerce")) {
+                                    KitUtils.hashForFiltering(event.eventType.value.toString() + key.trim())
+                                } else {
+                                    KitUtils.hashForFiltering(event.eventType.value.toString() + event.eventName.trim() + key.trim())
+                                }
 
                             configuration.eventAttributesAddToUser?.get(hashedKey)?.let {
                                 value.addToCustomAttributeArray(it, attributeValue)

--- a/src/test/kotlin/com/braze/Braze.kt
+++ b/src/test/kotlin/com/braze/Braze.kt
@@ -51,6 +51,10 @@ class Braze {
             events.clear()
         }
 
+        fun clearBrazeUser(){
+            currentUser.customUserAttributes.clear()
+            currentUser.customAttributeArray.clear()
+        }
         val currentUser = BrazeUser()
 
         @JvmStatic


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Added enum values instead of enum for hash e-commerce event attributes.
 - Added Separate logic for e-commerce event hash

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with sample application and executed unit test cases

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6551
