### PR TITLE
fix: Convert product list to JSON object when bundling commerce event.

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -27,9 +27,12 @@ import com.mparticle.identity.MParticleUser
 import com.mparticle.internal.Logger
 import com.mparticle.kits.CommerceEventUtils.OnAttributeExtracted
 import com.mparticle.kits.KitIntegration.*
+import org.json.JSONArray
+import org.json.JSONObject
 import java.math.BigDecimal
 import java.text.SimpleDateFormat
 import java.util.*
+import kotlin.collections.HashMap
 
 /**
  * mParticle client-side Appboy integration
@@ -731,95 +734,95 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         }
     }
 
-    fun getProductListParameters(productList: List<Product>): Array<BrazeProperties?> {
-        val productArray = arrayOfNulls<BrazeProperties>(productList.count())
+    fun getProductListParameters(productList: List<Product>): JSONArray {
+        val productArray = JSONArray()
         for ((i, product) in productList.withIndex()) {
-            val productProperties = BrazeProperties()
+            val productProperties = JSONObject()
 
             product.customAttributes?.let {
-                productProperties.addProperty(CUSTOM_ATTRIBUTES_KEY, it)
+                productProperties.put(CUSTOM_ATTRIBUTES_KEY, it)
             }
             product.couponCode?.let {
-                productProperties.addProperty(
+                productProperties.put(
                     CommerceEventUtils.Constants.ATT_PRODUCT_COUPON_CODE,
                     it
                 )
             }
             product.brand?.let {
-                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_BRAND, it)
+                productProperties.put(CommerceEventUtils.Constants.ATT_PRODUCT_BRAND, it)
             }
             product.category?.let {
-                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_CATEGORY, it)
+                productProperties.put(CommerceEventUtils.Constants.ATT_PRODUCT_CATEGORY, it)
             }
             product.name?.let {
-                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_NAME, it)
+                productProperties.put(CommerceEventUtils.Constants.ATT_PRODUCT_NAME, it)
             }
             product.sku?.let {
-                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_ID, it)
+                productProperties.put(CommerceEventUtils.Constants.ATT_PRODUCT_ID, it)
             }
             product.variant?.let {
-                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_VARIANT, it)
+                productProperties.put(CommerceEventUtils.Constants.ATT_PRODUCT_VARIANT, it)
             }
             product.position?.let {
-                productProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_POSITION, it)
+                productProperties.put(CommerceEventUtils.Constants.ATT_PRODUCT_POSITION, it)
             }
-            productProperties.addProperty(
+            productProperties.put(
                 CommerceEventUtils.Constants.ATT_PRODUCT_PRICE,
                 product.unitPrice
             )
-            productProperties.addProperty(
+            productProperties.put(
                 CommerceEventUtils.Constants.ATT_PRODUCT_QUANTITY,
                 product.quantity
             )
-            productProperties.addProperty(
+            productProperties.put(
                 CommerceEventUtils.Constants.ATT_PRODUCT_TOTAL_AMOUNT,
                 product.totalAmount
             )
 
-            productArray[i] = productProperties
+            productArray.put(productProperties)
         }
         return productArray
     }
 
-    fun getPromotionListParameters(promotionList: List<Promotion>): Array<BrazeProperties?> {
-        val promotionArray = arrayOfNulls<BrazeProperties>(promotionList.count())
+    fun getPromotionListParameters(promotionList: List<Promotion>): JSONArray {
+        val promotionArray = JSONArray()
         for ((i, promotion) in promotionList.withIndex()) {
-            val promotionProperties = BrazeProperties()
+            val promotionProperties = JSONObject()
             promotion.creative?.let {
-                promotionProperties.addProperty(
+                promotionProperties.put(
                     CommerceEventUtils.Constants.ATT_PROMOTION_CREATIVE,
                     it
                 )
             }
             promotion.id?.let {
-                promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_ID, it)
+                promotionProperties.put(CommerceEventUtils.Constants.ATT_PROMOTION_ID, it)
             }
             promotion.name?.let {
-                promotionProperties.addProperty(CommerceEventUtils.Constants.ATT_PROMOTION_NAME, it)
+                promotionProperties.put(CommerceEventUtils.Constants.ATT_PROMOTION_NAME, it)
             }
             promotion.position?.let {
-                promotionProperties.addProperty(
+                promotionProperties.put(
                     CommerceEventUtils.Constants.ATT_PROMOTION_POSITION,
                     it
                 )
             }
-            promotionArray[i] = promotionProperties
+            promotionArray.put(promotionProperties)
         }
         return promotionArray
     }
 
-    fun getImpressionListParameters(impressionList: List<Impression>): Array<BrazeProperties?> {
-        val impressionArray = arrayOfNulls<BrazeProperties>(impressionList.count())
+    fun getImpressionListParameters(impressionList: List<Impression>): JSONArray {
+        val impressionArray = JSONArray()
         for ((i, impression) in impressionList.withIndex()) {
-            val impressionProperties = BrazeProperties()
+            val impressionProperties = JSONObject()
             impression.listName?.let {
-                impressionProperties.addProperty("Product Impression List", it)
+                impressionProperties.put("Product Impression List", it)
             }
             impression.products?.let {
                 val productArray = getProductListParameters(it)
-                impressionProperties.addProperty(PRODUCT_KEY, productArray)
+                impressionProperties.put(PRODUCT_KEY, productArray)
             }
-            impressionArray[i] = impressionProperties
+            impressionArray.put(impressionProperties)
         }
         return impressionArray
     }

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -18,6 +18,7 @@ import com.mparticle.kits.mocks.MockAppboyKit
 import com.mparticle.kits.mocks.MockContextApplication
 import com.mparticle.kits.mocks.MockKitConfiguration
 import com.mparticle.kits.mocks.MockUser
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Before
@@ -504,7 +505,7 @@ class AppboyKitTests {
         Assert.assertNotNull(purchase.purchaseProperties)
         val properties = purchase.purchaseProperties.properties
         val productArray = properties.remove(AppboyKit.PRODUCT_KEY)
-        Assert.assertTrue(productArray is Array<*>)
+        Assert.assertTrue(productArray is JSONArray)
         if (productArray is Array<*>) {
             Assert.assertEquals(1, productArray.size.toLong())
             val productBrazeProperties = productArray[0]
@@ -629,7 +630,7 @@ class AppboyKitTests {
         val properties = event.properties
 
         val promotionArray = properties.remove(AppboyKit.PROMOTION_KEY)
-        Assert.assertTrue(promotionArray is Array<*>)
+        Assert.assertTrue(promotionArray is JSONArray)
         if (promotionArray is Array<*>) {
             Assert.assertEquals(1, promotionArray.size.toLong())
             val promotionBrazeProperties = promotionArray[0]
@@ -734,7 +735,7 @@ class AppboyKitTests {
         val properties = event.properties
 
         val impressionArray = properties.remove(AppboyKit.IMPRESSION_KEY)
-        Assert.assertTrue(impressionArray is Array<*>)
+        Assert.assertTrue(impressionArray is JSONArray)
         if (impressionArray is Array<*>) {
             Assert.assertEquals(1, impressionArray.size.toLong())
             val impressionBrazeProperties = impressionArray[0]


### PR DESCRIPTION

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Added JSON objects to replace BrazeProperties for handling Product Lists, Impression Lists, and Promotion Lists.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested it with a sample application and ran unit tests.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6543
