### PR TITLE
feat: Send ProductName to Braze

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -615,7 +615,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
 
         var sanitizedProductName: String = product.sku
         try {
-            if (settings[FORWARD_SKU_AS_PRODUCT_NAME] == "True") {
+            if (settings[REPLACE_SKU_AS_PRODUCT_NAME] == "True") {
                 sanitizedProductName = product.name
             }
         } catch (e: Exception) {
@@ -1086,7 +1086,8 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         const val HOST = "host"
         const val PUSH_ENABLED = "push_enabled"
         const val NAME = "Appboy"
-        const val FORWARD_SKU_AS_PRODUCT_NAME = "forwardSkuAsProductName"
+        // if this flag is true, kit will send Product name as sku
+        const val REPLACE_SKU_AS_PRODUCT_NAME = "forwardSkuAsProductName"
         private const val PREF_KEY_HAS_SYNCED_ATTRIBUTES = "appboy::has_synced_attributes"
         private const val PREF_KEY_CURRENT_EMAIL = "appboy::current_email"
         private const val FLUSH_DELAY = 5000

--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -613,8 +613,18 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
             }
         }
 
+        var sanitizedProductName: String = product.sku
+        try {
+            if (settings[FORWARD_SKU_AS_PRODUCT_NAME] == "True") {
+                sanitizedProductName = product.name
+            }
+        } catch (e: Exception) {
+            Logger.error(e, "The Braze kit threw an exception while searching for forward sku as product name flag.")
+
+        }
+
         Braze.Companion.getInstance(context).logPurchase(
-            product.sku,
+            sanitizedProductName,
             currencyValue,
             BigDecimal(product.unitPrice),
             product.quantity.toInt(),
@@ -1076,6 +1086,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         const val HOST = "host"
         const val PUSH_ENABLED = "push_enabled"
         const val NAME = "Appboy"
+        const val FORWARD_SKU_AS_PRODUCT_NAME = "forwardSkuAsProductName"
         private const val PREF_KEY_HAS_SYNCED_ATTRIBUTES = "appboy::has_synced_attributes"
         private const val PREF_KEY_CURRENT_EMAIL = "appboy::current_email"
         private const val FLUSH_DELAY = 5000

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -1295,7 +1295,7 @@ class AppboyKitTests {
     fun testPurchase_Forward_product_name() {
         var settings = HashMap<String, String?>()
         settings[AppboyKit.APPBOY_KEY] = "key"
-        settings[AppboyKit.FORWARD_SKU_AS_PRODUCT_NAME] = "True"
+        settings[AppboyKit.REPLACE_SKU_AS_PRODUCT_NAME] = "True"
         val kit = MockAppboyKit()
 
         kit.configuration =
@@ -1319,7 +1319,7 @@ class AppboyKitTests {
     fun testPurchase_Forward_product_name_When_flag_IS_FALSE() {
         var settings = HashMap<String, String?>()
         settings[AppboyKit.APPBOY_KEY] = "key"
-        settings[AppboyKit.FORWARD_SKU_AS_PRODUCT_NAME] = "False"
+        settings[AppboyKit.REPLACE_SKU_AS_PRODUCT_NAME] = "False"
         val kit = MockAppboyKit()
 
         kit.configuration =

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -964,7 +964,7 @@ class AppboyKitTests {
         eaaObject.put("eaa", mapValue)
         jsonObject.put("hs", eaaObject)
 
-        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0) 
+        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0)
 
         var kitConfiguration = MockKitConfiguration.createKitConfiguration(jsonObject)
         kit.configuration = kitConfiguration
@@ -1002,7 +1002,7 @@ class AppboyKitTests {
         eaaObject.put("ear", mapValue)
         jsonObject.put("hs", eaaObject)
 
-        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0) 
+        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0)
 
         var kitConfiguration = MockKitConfiguration.createKitConfiguration(jsonObject)
         kit.configuration = kitConfiguration
@@ -1033,7 +1033,7 @@ class AppboyKitTests {
         eaaObject.put("eas", mapValue)
         jsonObject.put("hs", eaaObject)
 
-        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0) 
+        Mockito.`when`(mTypeFilters!!.size()).thenReturn(0)
 
         var kitConfiguration = MockKitConfiguration.createKitConfiguration(jsonObject)
         kit.configuration = kitConfiguration
@@ -1289,5 +1289,76 @@ class AppboyKitTests {
 
         TestCase.assertEquals(0, currentUser.getCustomUserAttribute().size)
 
+    }
+
+    @Test
+    fun testPurchase_Forward_product_name() {
+        var settings = HashMap<String, String?>()
+        settings[AppboyKit.APPBOY_KEY] = "key"
+        settings[AppboyKit.FORWARD_SKU_AS_PRODUCT_NAME] = "True"
+        val kit = MockAppboyKit()
+
+        kit.configuration =
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+        kit.onKitCreate(settings, MockContextApplication())
+        val product = Product.Builder("product name", "sku1", 4.5)
+            .build()
+        val commerceEvent = CommerceEvent.Builder(Product.CHECKOUT, product)
+            .currency("Moon Dollars")
+            .build()
+        kit.logTransaction(commerceEvent, product)
+        val braze = Braze
+        val purchases = braze.purchases
+        Assert.assertEquals(1, purchases.size.toLong())
+        val purchase = purchases[0]
+        Assert.assertEquals("product name", purchase.sku)
+        Assert.assertNull(purchase.purchaseProperties.properties[CommerceEventUtils.Constants.ATT_ACTION_CURRENCY_CODE])
+    }
+
+    @Test
+    fun testPurchase_Forward_product_name_When_flag_IS_FALSE() {
+        var settings = HashMap<String, String?>()
+        settings[AppboyKit.APPBOY_KEY] = "key"
+        settings[AppboyKit.FORWARD_SKU_AS_PRODUCT_NAME] = "False"
+        val kit = MockAppboyKit()
+
+        kit.configuration =
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+        kit.onKitCreate(settings, MockContextApplication())
+        val product = Product.Builder("product name", "sku1", 4.5)
+            .build()
+        val commerceEvent = CommerceEvent.Builder(Product.CHECKOUT, product)
+            .currency("Moon Dollars")
+            .build()
+        kit.logTransaction(commerceEvent, product)
+        val braze = Braze
+        val purchases = braze.purchases
+        Assert.assertEquals(1, purchases.size.toLong())
+        val purchase = purchases[0]
+        Assert.assertEquals("sku1", purchase.sku)
+        Assert.assertNull(purchase.purchaseProperties.properties[CommerceEventUtils.Constants.ATT_ACTION_CURRENCY_CODE])
+    }
+
+    @Test
+    fun testPurchase_Forward_product_name_When_flag_IS_Null() {
+        var settings = HashMap<String, String?>()
+        settings[AppboyKit.APPBOY_KEY] = "key"
+        val kit = MockAppboyKit()
+
+        kit.configuration =
+            KitConfiguration.createKitConfiguration(JSONObject().put("as", settings))
+        kit.onKitCreate(settings, MockContextApplication())
+        val product = Product.Builder("product name", "sku1", 4.5)
+            .build()
+        val commerceEvent = CommerceEvent.Builder(Product.CHECKOUT, product)
+            .currency("Moon Dollars")
+            .build()
+        kit.logTransaction(commerceEvent, product)
+        val braze = Braze
+        val purchases = braze.purchases
+        Assert.assertEquals(1, purchases.size.toLong())
+        val purchase = purchases[0]
+        Assert.assertEquals("sku1", purchase.sku)
+        Assert.assertNull(purchase.purchaseProperties.properties[CommerceEventUtils.Constants.ATT_ACTION_CURRENCY_CODE])
     }
 }


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Right now, in Android, we send product SKUs to Braze. The product name should also be sent for the native kits, just like we do for the Web kit. If a setting is enabled, the product name should be sent; otherwise, the SKU should be sent to Braze.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with the sample app and executed unit test cases

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6888
