### PR TITLE
feat: Send ProductName to Braze (update flag)

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -1076,6 +1076,11 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         const val HOST = "host"
         const val PUSH_ENABLED = "push_enabled"
         const val NAME = "Appboy"
+<<<<<<< Updated upstream
+=======
+        // if this flag is true, kit will send Product name as sku
+        const val REPLACE_SKU_AS_PRODUCT_NAME = "replaceSkuWithProductName"
+>>>>>>> Stashed changes
         private const val PREF_KEY_HAS_SYNCED_ATTRIBUTES = "appboy::has_synced_attributes"
         private const val PREF_KEY_CURRENT_EMAIL = "appboy::current_email"
         private const val FLUSH_DELAY = 5000


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - Right now, in Android, we send product SKUs to Braze. The product name should also be sent for the native kits, just like we do for the Web kit. If a setting is enabled, the product name should be sent; otherwise, the SKU should be sent to Braze. Just update flag.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested with the sample app and executed unit test cases

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6888
