### PR TITLE
feat: Add support to forward SubscriptionGroupIds

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -328,9 +328,11 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                                 "true" -> {
                                     groupId?.let { value.addToSubscriptionGroup(it) }
                                 }
+
                                 "false" -> {
                                     groupId?.let { value.removeFromSubscriptionGroup(it) }
                                 }
+
                                 else -> {
                                     Logger.warning(
                                         "Unable to set Subscription Group ID for user attribute: $key due to invalid value data type. Expected Boolean."
@@ -996,7 +998,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
 
         val subscriptionGroupsArray = JSONArray(subscriptionGroupMap)
 
-        return try{
+        return try {
             for (i in 0 until subscriptionGroupsArray.length()) {
                 val subscriptionGroup = subscriptionGroupsArray.getJSONObject(i)
                 val key = subscriptionGroup.getString("map")

--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -47,6 +47,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
     var bundleCommerceEvents = false
     var isMpidIdentityType = false
     var identityType: IdentityType? = null
+    var subscriptionGroupIds: MutableMap<String, String>? = mutableMapOf()
     private val dataFlushHandler = Handler()
     private var dataFlushRunnable: Runnable? = null
     private var forwardScreenViews = false
@@ -85,6 +86,9 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
             }
         }
         forwardScreenViews = settings[FORWARD_SCREEN_VIEWS].toBoolean()
+        subscriptionGroupIds = settings[SUBSCRIPTION_GROUP_MAPPING]?.let {
+            getSubscriptionGroupIds(it)
+        }
         if (key != null) {
             val config = BrazeConfig.Builder().setApiKey(key)
                 .setSdkFlavor(SdkFlavor.MPARTICLE)
@@ -318,10 +322,27 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
                         else value.setGender(Gender.MALE)
                     }
                     else -> {
-                        if (key.startsWith("$")) {
-                            key = key.substring(1)
+                        if (subscriptionGroupIds?.containsKey(key) == true) {
+                            if (attributeValue == "true") {
+                                value.addToSubscriptionGroup(
+                                    subscriptionGroupIds?.get(key).toString()
+                                )
+                            } else if (attributeValue == "false") {
+                                value.removeFromSubscriptionGroup(
+                                    subscriptionGroupIds?.get(key).toString()
+                                )
+                            } else {
+                                Logger.warning(
+                                    "unable to set Subscription Group ID for user attribute: "
+                                            + key + "due to invalid value data type. expected value data type should be Boolean"
+                                )
+                            }
+                        } else {
+                            if (key.startsWith("$")) {
+                                key = key.substring(1)
+                            }
+                            userAttributeSetter?.parseValue(key, attributeValue)
                         }
-                        userAttributeSetter?.parseValue(key, attributeValue)
                     }
                 }
                 queueDataFlush()
@@ -966,6 +987,24 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         return promotionArray
     }
 
+    private fun getSubscriptionGroupIds(subscriptionGroupMap: String): MutableMap<String, String> {
+        val subscriptionGroupsArray = JSONArray(subscriptionGroupMap)
+        val subscriptionGroupIds = mutableMapOf<String, String>()
+
+        if (subscriptionGroupMap.isEmpty()) {
+            return subscriptionGroupIds
+        }
+
+        for (i in 0 until subscriptionGroupsArray.length()) {
+            val subscriptionGroup = subscriptionGroupsArray.getJSONObject(i)
+            val key = subscriptionGroup.getString("map")
+            val value = subscriptionGroup.getString("value")
+            subscriptionGroupIds[key] = value
+        }
+
+        return subscriptionGroupIds
+    }
+
     fun getImpressionListParameters(impressionList: List<Impression>): JSONArray {
         val impressionArray = JSONArray()
         for ((i, impression) in impressionList.withIndex()) {
@@ -1083,6 +1122,7 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
         const val USER_IDENTIFICATION_TYPE = "userIdentificationType"
         const val ENABLE_TYPE_DETECTION = "enableTypeDetection"
         const val BUNDLE_COMMERCE_EVENTS = "bundleCommerceEventData"
+        const val SUBSCRIPTION_GROUP_MAPPING = "subscriptionGroupMapping"
         const val HOST = "host"
         const val PUSH_ENABLED = "push_enabled"
         const val NAME = "Appboy"

--- a/src/test/kotlin/com/braze/BrazeUser.kt
+++ b/src/test/kotlin/com/braze/BrazeUser.kt
@@ -58,6 +58,16 @@ class BrazeUser {
         return true
     }
 
+    fun addToSubscriptionGroup(key: String): Boolean {
+        customUserAttributes[key] = true
+        return true
+    }
+
+    fun removeFromSubscriptionGroup(key: String): Boolean {
+        customUserAttributes[key] = false
+        return true
+    }
+
     fun getCustomAttribute(): HashMap<String, MutableList<String>> {
         return customAttributeArray
     }

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -238,6 +238,25 @@ class AppboyKitTests {
         Assert.assertNull(kit.getCalendarMinusYears(-1))
     }
 
+    @Test
+    fun testSetSubscriptionGroupIds() {
+        val settings = HashMap<String, String>()
+        settings[AppboyKit.APPBOY_KEY] = "key"
+        settings[AppboyKit.HOST] = hostName
+        settings["subscriptionGroupMapping"] = "" +
+                "[{\"jsmap\":null,\"map\":\"test1\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"00000000-0000-0000-0000-000000000000\"}," +
+                "{\"jsmap\":null,\"map\":\"test2\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"00000000-0000-0000-0000-000000000001\"}," +
+                "{\"jsmap\":null,\"map\":\"test3\",\"maptype\":\"UserAttributeClass.Name\",\"value\":\"00000000-0000-0000-0000-000000000002\"}]"
+        val kit = MockAppboyKit()
+        val currentUser = braze.currentUser
+
+        kit.onKitCreate(settings, MockContextApplication())
+        kit.setUserAttribute("test1", "true");
+        kit.setUserAttribute("test2", "false");
+        kit.setUserAttribute("test3", "notABoolean");
+        Assert.assertEquals(2, currentUser.getCustomUserAttribute().size.toLong())
+    }
+
 //    @Test
 //    fun testSetUserAttributeAge() {
 //        val currentYear = Calendar.getInstance()[Calendar.YEAR]


### PR DESCRIPTION
 ## Summary
 - We currently support forwarding subscriptionGroupIds mapped via user attributes in our Braze S2S forwarder only, a customer mentioned that Braze support this feature in their Braze and requested this as a feature to our kits, refer to our [docs](https://docs.mparticle.com/integrations/braze/event/#subscription-groups) regarding subscription group ids

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and Unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7232
