### PR TITLE
feat: Update Braze to v35.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
-    api 'com.braze:android-sdk-ui:34.0.0'
+    api 'com.braze:android-sdk-ui:35.0.0'
     testImplementation  files('libs/java-json.jar')
 }


### PR DESCRIPTION
 ## Summary
 - update Braze SDK to v35.0.0

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and Unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7195
