### PR TITLE
fix: Forward product attribute with purchase events when products not…

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppboyKit.kt
@@ -636,6 +636,33 @@ open class AppboyKit : KitIntegration(), AttributeListener, CommerceListener,
             }
         }
 
+        product.couponCode?.let {
+            purchaseProperties.addProperty(
+                CommerceEventUtils.Constants.ATT_PRODUCT_COUPON_CODE,
+                it
+            )
+        }
+        product.brand?.let {
+            purchaseProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_BRAND, it)
+        }
+        product.category?.let {
+            purchaseProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_CATEGORY, it)
+        }
+        product.name.let {
+            purchaseProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_NAME, it)
+        }
+        product.variant?.let {
+            purchaseProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_VARIANT, it)
+        }
+        product.position?.let {
+            purchaseProperties.addProperty(CommerceEventUtils.Constants.ATT_PRODUCT_POSITION, it)
+        }
+        product.customAttributes?.let {
+            for ((key, value) in it) {
+                purchaseProperties.addProperty(key, value)
+            }
+        }
+
         var sanitizedProductName: String = product.sku
         try {
             if (settings[REPLACE_SKU_AS_PRODUCT_NAME] == "True") {

--- a/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
+++ b/src/test/kotlin/com/mparticle/kits/AppboyKitTest.kt
@@ -441,6 +441,9 @@ class AppboyKitTests {
         val customAttributes = HashMap<String, String>()
         customAttributes["key1"] = "value1"
         customAttributes["key #2"] = "value #3"
+        val productCustomAttributes = HashMap<String, String>()
+        productCustomAttributes["productKey1"] = "value1"
+        productCustomAttributes["productKey2"] = "value2"
         val transactionAttributes = TransactionAttributes("the id")
             .setTax(100.0)
             .setShipping(12.0)
@@ -449,6 +452,11 @@ class AppboyKitTests {
             .setAffiliation("the affiliation")
         val product = Product.Builder("product name", "sku1", 4.5)
             .quantity(5.0)
+            .brand("testBrand")
+            .variant("testVariant")
+            .position(1)
+            .category("testCategory")
+            .customAttributes(productCustomAttributes)
             .build()
         val commerceEvent = CommerceEvent.Builder(Product.PURCHASE, product)
             .currency("Moon Dollars")
@@ -491,10 +499,34 @@ class AppboyKitTests {
             properties.remove(CommerceEventUtils.Constants.ATT_AFFILIATION),
             "the affiliation"
         )
+        Assert.assertEquals(
+            properties.remove(CommerceEventUtils.Constants.ATT_PRODUCT_NAME),
+            "product name"
+        )
+        Assert.assertEquals(
+            properties.remove(CommerceEventUtils.Constants.ATT_PRODUCT_CATEGORY),
+            "testCategory"
+        )
+        Assert.assertEquals(
+            properties.remove(CommerceEventUtils.Constants.ATT_PRODUCT_BRAND),
+            "testBrand"
+        )
+        Assert.assertEquals(
+            properties.remove(CommerceEventUtils.Constants.ATT_PRODUCT_POSITION),
+            1
+        )
+        Assert.assertEquals(
+            properties.remove(CommerceEventUtils.Constants.ATT_PRODUCT_VARIANT),
+            "testVariant"
+        )
 
         //Custom Attributes
         Assert.assertEquals(properties.remove("key1"), "value1")
         Assert.assertEquals(properties.remove("key #2"), "value #3")
+
+        //Product Custom Attributes
+        Assert.assertEquals(properties.remove("productKey1"), "value1")
+        Assert.assertEquals(properties.remove("productKey2"), "value2")
 
         val emptyAttributes = HashMap<String, String>()
         Assert.assertEquals(emptyAttributes, properties)


### PR DESCRIPTION
… bundled

 ## Summary
 - While working on SQDSDKS-7359 and comparing the iOS and Android Braze kits, I've noticed that the Android Braze kit doesn't forward a product's reserved attributes (i,e Brand, Variant, Category) and its custom attributes with purchase events when bundleCommerceEvents is set to false while the iOS kit does. 

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E and unit tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7394
