### PR TITLE
fix: Replace mock KitListener with an anonymous implementation in constructor

### DIFF
--- a/src/test/kotlin/com/mparticle/kits/mocks/MockCoreCallbacks.kt
+++ b/src/test/kotlin/com/mparticle/kits/mocks/MockCoreCallbacks.kt
@@ -59,6 +59,13 @@ class MockCoreCallbacks : CoreCallbacks {
     }
 
     override fun getKitListener(): KitListener {
-        return CoreCallbacks.KitListener.EMPTY
+        return object : KitListener {
+            override fun kitFound(kitId: Int) {}
+            override fun kitConfigReceived(kitId: Int, configuration: String?) {}
+            override fun kitExcluded(kitId: Int, reason: String?) {}
+            override fun kitStarted(kitId: Int) {}
+            override fun onKitApiCalled(kitId: Int, used: Boolean?, vararg objects: Any?) {}
+            override fun onKitApiCalled(methodName: String?, kitId: Int, used: Boolean?, vararg objects: Any?) {}
+        }
     }
 }

--- a/src/test/kotlin/com/mparticle/kits/mocks/MockKitManagerImpl.kt
+++ b/src/test/kotlin/com/mparticle/kits/mocks/MockKitManagerImpl.kt
@@ -30,7 +30,14 @@ class MockKitManagerImpl(
             CoreCallbacks::class.java
         )
     ) {
-        Mockito.`when`(mCoreCallbacks.getKitListener()).thenReturn(CoreCallbacks.KitListener.EMPTY)
+        Mockito.`when`(mCoreCallbacks.getKitListener()).thenReturn(object : KitListener {
+            override fun kitFound(kitId: Int) {}
+            override fun kitConfigReceived(kitId: Int, configuration: String?) {}
+            override fun kitExcluded(kitId: Int, reason: String?) {}
+            override fun kitStarted(kitId: Int) {}
+            override fun onKitApiCalled(kitId: Int, used: Boolean?, vararg objects: Any?) {}
+            override fun onKitApiCalled(methodName: String?, kitId: Int, used: Boolean?, vararg objects: Any?) {}
+        })
     }
 
     @Throws(JSONException::class)


### PR DESCRIPTION

## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
 - This PR addresses a Kotlin Lint issue by replacing the mock KitListener with a more complete anonymous implementation in the constructor and the getKitListener() method.

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - {explain how this has been tested, and what, if any, additional testing should be done}

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/REPLACEME
