### PR TITLE
feat: Update Braze SDK to 41.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         classpath 'com.mparticle:android-kit-plugin:' + project.version
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
@@ -67,6 +67,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.google.firebase:firebase-messaging:[10.2.1, )'
-    api 'com.braze:android-sdk-ui:37.0.0'
+    api 'com.braze:android-sdk-ui:41.1.1'
     testImplementation  files('libs/java-json.jar')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
In my testing, Braze 41 was not sending events when using the example app. This requires upgrading AGP from 8.1.4 to 8.7.3 and Gradle from 8.0.2 to 8.9 because Braze 41 depends on androidx.datastore 1.1.x (a Kotlin Multiplatform library) which needs AGP 8.6+ for correct Android variant resolution.

- Update Braze Android SDK from 37.0.0 to 41.1.1
- No breaking API changes affect this kit (News Feed removal, `InAppMessageCloser` removal, location collection renames are not used)
- Changelog: https://github.com/braze-inc/braze-android-sdk/blob/master/CHANGELOG.md

## Breaking changes in Braze SDK v37 → v41 (none affect this kit)
- **v38**: News Feed removed entirely
- **v39**: `subscribeToContentCardsUpdates()` behavior change (returns cached cards immediately)
- **v40**: `InAppMessageCloser` removed; `DeviceKey.RESOLUTION` removed
- **v41**: Location collection config methods renamed

## Test plan
- [x] Verify kit compiles against Braze SDK 41.0.0
- [x] Run existing unit tests
- [ ] Validate push notification handling still works
- [x] Validate event/purchase logging still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)